### PR TITLE
Allow File/Replace dialog options to be saved

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -5352,6 +5352,29 @@ void LoadSettings(void) {
 	xFindReplaceDlg = IniSectionGetInt(pIniSection, L"FindReplaceDlgPosX", 0);
 	yFindReplaceDlg = IniSectionGetInt(pIniSection, L"FindReplaceDlgPosY", 0);
 
+	if (bSaveFindReplace) {
+		efrData.fuFlags = 0;
+		if (IniSectionGetBool(pIniSection, L"FindReplaceMatchCase", 0)) {
+			efrData.fuFlags |= SCFIND_MATCHCASE;
+		}
+		if (IniSectionGetBool(pIniSection, L"FindReplaceMatchWholeWorldOnly", 0)) {
+			efrData.fuFlags |= SCFIND_WHOLEWORD;
+		}
+		if (IniSectionGetBool(pIniSection, L"FindReplaceMatchBeginingWordOnly", 0)) {
+			efrData.fuFlags |= SCFIND_WORDSTART;
+		}
+		if (IniSectionGetBool(pIniSection, L"FindReplaceRegExpSearch", 0)) {
+			efrData.fuFlags |= SCFIND_REGEXP | SCFIND_POSIX;
+		}
+		efrData.bTransformBS = IniSectionGetBool(pIniSection, L"FindReplaceTransformBackslash", 0);
+		efrData.bNoFindWrap = IniSectionGetBool(pIniSection, L"FindReplaceDontWrapRound", 0);
+		efrData.bFindClose = IniSectionGetBool(pIniSection, L"FindReplaceCloseAfterFind", 0);
+		efrData.bReplaceClose = IniSectionGetBool(pIniSection, L"FindReplaceCloseAfterReplace", 0);
+#ifdef BOOKMARK_EDITION
+		efrData.bWildcardSearch = IniSectionGetBool(pIniSection, L"FindReplaceWildcardSearch", 0);
+#endif
+	}
+
 //////////////////////////////// Settings2 ///////////////////////////////////////////
 
 	LoadIniSection(L"Settings2", pIniSection, cchIniSection);
@@ -5532,6 +5555,20 @@ void SaveSettings(BOOL bSaveSettingsNow) {
 	IniSectionSetInt(pIniSection, L"FavoritesDlgSizeY", cyFavoritesDlg);
 	IniSectionSetInt(pIniSection, L"FindReplaceDlgPosX", xFindReplaceDlg);
 	IniSectionSetInt(pIniSection, L"FindReplaceDlgPosY", yFindReplaceDlg);
+
+	if (bSaveFindReplace) {
+		IniSectionSetBool(pIniSection, L"FindReplaceMatchCase", (efrData.fuFlags & SCFIND_MATCHCASE) ? 1 : 0 );
+		IniSectionSetBool(pIniSection, L"FindReplaceMatchWholeWorldOnly", (efrData.fuFlags & SCFIND_WHOLEWORD) ? 1 : 0 );
+		IniSectionSetBool(pIniSection, L"FindReplaceMatchBeginingWordOnly", (efrData.fuFlags & SCFIND_WORDSTART) ? 1 : 0 );
+		IniSectionSetBool(pIniSection, L"FindReplaceRegExpSearch", (efrData.fuFlags & (SCFIND_REGEXP | SCFIND_POSIX)) ? 1 : 0 );
+		IniSectionSetBool(pIniSection, L"FindReplaceTransformBackslash", efrData.bTransformBS);
+		IniSectionSetBool(pIniSection, L"FindReplaceDontWrapRound", efrData.bNoFindWrap);
+		IniSectionSetBool(pIniSection, L"FindReplaceCloseAfterFind", efrData.bFindClose);
+		IniSectionSetBool(pIniSection, L"FindReplaceCloseAfterReplace", efrData.bReplaceClose);
+#ifdef BOOKMARK_EDITION
+		IniSectionSetBool(pIniSection, L"FindReplaceWildcardSearch", efrData.bWildcardSearch);
+#endif
+	}
 
 	SaveIniSection(L"Settings", pIniSection);
 	LocalFree(pIniSection);

--- a/src/Notepad2.rc
+++ b/src/Notepad2.rc
@@ -472,7 +472,7 @@ BEGIN
         END
         MENUITEM "Sa&ve Before Running Tools",  IDM_VIEW_SAVEBEFORERUNNINGTOOLS
         MENUITEM "Remember Recent F&iles",      IDM_VIEW_NOSAVERECENT
-        MENUITEM "Remember S&earch Strings",    IDM_VIEW_NOSAVEFINDREPL
+        MENUITEM "Remember S&earch Options",    IDM_VIEW_NOSAVEFINDREPL
         MENUITEM SEPARATOR
         MENUITEM "Sh&ow Toolbar",               IDM_VIEW_TOOLBAR
         MENUITEM "C&ustomize Toolbar...",       IDM_VIEW_CUSTOMIZETB


### PR DESCRIPTION
This fix will helps in saving the options checked/unchecked
in File/Replace dialog to be persisted to notepad2.ini