### PR TITLE
Make 'Would you like to create this file' MsgBox cancellable with Esc or Alt+F4

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -6932,7 +6932,8 @@ BOOL FileLoad(BOOL bDontSave, BOOL bNew, BOOL bReload, BOOL bNoEncDetect, LPCWST
 	};
 	// Ask to create a new file...
 	if (!bReload && !PathFileExists(szFileName)) {
-		if (flagQuietCreate || MsgBox(MBYESNO, IDS_ASK_CREATE, szFileName) == IDYES) {
+		UINT result = IDCANCEL;
+		if (flagQuietCreate || (result = MsgBox(MBYESNOCANCEL, IDS_ASK_CREATE, szFileName)) == IDYES) {
 			HANDLE hFile = CreateFile(szFileName,
 									  GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
 									  NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -6955,6 +6956,9 @@ BOOL FileLoad(BOOL bDontSave, BOOL bNew, BOOL bReload, BOOL bNoEncDetect, LPCWST
 				SendMessage(hwndEdit, SCI_SETCODEPAGE, (iEncoding == CPI_DEFAULT) ? iDefaultCodePage : SC_CP_UTF8, 0);
 				bReadOnly = FALSE;
 			}
+		} else if (result == IDCANCEL) {
+			NP2ExitWind(hwndMain);
+			return FALSE;
 		} else {
 			return FALSE;
 		}


### PR DESCRIPTION
When opening Notepad2 with non existing file path, It asks for a
confirmation Message Box. The current MsgBox uses MBYESNO instead of
MBYESNOCANCEL because of which we cannot close/quit the notepad2 with
Esc or Alt+F4. By making it MBYESNOCANCEL user can perform below actions

1. Click 'Yes' - To create a new file with the specified name
2. Click 'No' - To create an empty window
3. Click 'Cancel' - To exit the notepad with either Esc/Alt+F4