### PR TITLE
Allow Goto dialog to support line number text to have non numeric suffixes

### DIFF
--- a/src/Edit.c
+++ b/src/Edit.c
@@ -5443,8 +5443,7 @@ static INT_PTR CALLBACK EditLineNumDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, 
 			// Extract line number from the text entered
 			// For example: "5410:" will result in 5410
 			GetDlgItemText(hwnd, IDC_LINENUM, tchLn, COUNTOF(tchLn));
-			swscanf_s(tchLn, L"%d", &iNewLine);
-			fTranslated = (iNewLine != 0);
+			fTranslated = CRTStrToInt(tchLn, &iNewLine);
 
 			if (SendDlgItemMessage(hwnd, IDC_COLNUM, WM_GETTEXTLENGTH, 0, 0) > 0) {
 				iNewCol = GetDlgItemInt(hwnd, IDC_COLNUM, &fTranslated2, FALSE);

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -5436,9 +5436,15 @@ static INT_PTR CALLBACK EditLineNumDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, 
 		case IDOK: {
 			BOOL fTranslated;
 			BOOL fTranslated2;
-
-			const int iNewLine = (int)GetDlgItemInt(hwnd, IDC_LINENUM, &fTranslated, FALSE);
+			WCHAR tchLn[32];
+			int iNewLine = 0;
 			int iNewCol;
+
+			// Extract line number from the text entered
+			// For example: "5410:" will result in 5410
+			GetDlgItemText(hwnd, IDC_LINENUM, tchLn, COUNTOF(tchLn));
+			swscanf_s(tchLn, L"%d", &iNewLine);
+			fTranslated = (iNewLine != 0);
 
 			if (SendDlgItemMessage(hwnd, IDC_COLNUM, WM_GETTEXTLENGTH, 0, 0) > 0) {
 				iNewCol = GetDlgItemInt(hwnd, IDC_COLNUM, &fTranslated2, FALSE);


### PR DESCRIPTION


This patch enables the line number field in the Goto dialog to accept text with
non numeric character suffixes. For example when you do grep/ripgrep the output
contains something like below.

```
    D:\repos\notepad2\src>rg LINENUM
    Notepad2.rc
    404:        MENUITEM "Line &Numbers\tCtrl+Shift+N",     IDM_VIEW_LINENUMBERS
    745:    "N",            IDM_VIEW_LINENUMBERS,   VIRTKEY, SHIFT, CONTROL, NOINVERT
    1055: IDD_LINENUM DIALOGEX 0, 0, 166, 70
    1061:    EDITTEXT        IDC_LINENUM,7,18,90,14,ES_AUTOHSCROLL
    1535:    IDD_LINENUM, DIALOG
```

It is so much easier to copy the line number by double clicking on the line number
in the CMD and paste it in the Goto dialog. Without this fix we cannot directly
use the copied text as it includes the semi-colon(':')