### PR TITLE
Do not search in PATH when opening relative paths via command line

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -6876,12 +6876,6 @@ BOOL FileLoad(BOOL bDontSave, BOOL bNew, BOOL bReload, BOOL bNoEncDetect, LPCWST
 	if (PathIsRelative(tch)) {
 		lstrcpyn(szFileName, g_wchWorkingDirectory, COUNTOF(szFileName));
 		PathAppend(szFileName, tch);
-		if (!PathFileExists(szFileName)) {
-			WCHAR wchFullPath[MAX_PATH];
-			if (SearchPath(NULL, tch, NULL, COUNTOF(wchFullPath), wchFullPath, NULL)) {
-				lstrcpy(szFileName, wchFullPath);
-			}
-		}
 	} else {
 		lstrcpy(szFileName, tch);
 	}
@@ -7326,17 +7320,7 @@ BOOL ActivatePrevInst(void) {
 		if (PathIsRelative(lpFileArg)) {
 			lstrcpyn(tchTmp, g_wchWorkingDirectory, COUNTOF(tchTmp));
 			PathAppend(tchTmp, lpFileArg);
-			if (PathFileExists(tchTmp)) {
-				lstrcpy(lpFileArg, tchTmp);
-			} else {
-				if (SearchPath(NULL, lpFileArg, NULL, COUNTOF(tchTmp), tchTmp, NULL)) {
-					lstrcpy(lpFileArg, tchTmp);
-				} else {
-					lstrcpyn(tchTmp, g_wchWorkingDirectory, COUNTOF(tchTmp));
-					PathAppend(tchTmp, lpFileArg);
-					lstrcpy(lpFileArg, tchTmp);
-				}
-			}
+			lstrcpy(lpFileArg, tchTmp);
 		} else if (SearchPath(NULL, lpFileArg, NULL, COUNTOF(tchTmp), tchTmp, NULL)) {
 			lstrcpy(lpFileArg, tchTmp);
 		}


### PR DESCRIPTION
When following command is executed `notepad2.exe config` instead of asking for
"File not found would you like to create" dialog, it tries to open
C:\Windows\system32\config with open file dialog. This is happening because
notepad2 tries to search in PATH variable when a relative path is provided

Fix: Do not search in PATH variable when a relative path is given at the command line

Signed-off-by: Vineel Kumar Reddy Kovvuri <vineel.kovvuri@gmail.com>