### PR TITLE
SetModEventMask before AppendText

### DIFF
--- a/src/Edit.c
+++ b/src/Edit.c
@@ -152,7 +152,7 @@ void EditSetNewText(LPCSTR lpstrText, DWORD cbText, Sci_Line lineCount) {
 	FileVars_Apply(&fvCurFile);
 
 	if (cbText > 0) {
-		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
+		SciCall_SetModEventMask(SC_MOD_NONE);
 #if 0
 		StopWatch watch;
 		StopWatch_Start(watch);
@@ -163,6 +163,7 @@ void EditSetNewText(LPCSTR lpstrText, DWORD cbText, Sci_Line lineCount) {
 		StopWatch_Stop(watch);
 		StopWatch_ShowLog(&watch, "AddText time");
 #endif
+		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
 	}
 
 	SciCall_SetUndoCollection(TRUE);
@@ -252,8 +253,9 @@ void EditConvertToLargeMode(void) {
 	FileVars_Apply(&fvCurFile);
 
 	if (length > 0) {
-		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
+		SciCall_SetModEventMask(SC_MOD_NONE);
 		SciCall_AppendText(length, pchText);
+		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
 	}
 	if (pchText != NULL) {
 		NP2HeapFree(pchText);

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -152,7 +152,7 @@ void EditSetNewText(LPCSTR lpstrText, DWORD cbText, Sci_Line lineCount) {
 	FileVars_Apply(&fvCurFile);
 
 	if (cbText > 0) {
-		SciCall_SetModEventMask(SC_MOD_NONE);
+		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
 #if 0
 		StopWatch watch;
 		StopWatch_Start(watch);
@@ -163,7 +163,6 @@ void EditSetNewText(LPCSTR lpstrText, DWORD cbText, Sci_Line lineCount) {
 		StopWatch_Stop(watch);
 		StopWatch_ShowLog(&watch, "AddText time");
 #endif
-		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
 	}
 
 	SciCall_SetUndoCollection(TRUE);
@@ -210,9 +209,8 @@ BOOL EditConvertText(UINT cpSource, UINT cpDest, BOOL bSetSavePoint) {
 	SciCall_SetCodePage(cpDest);
 
 	if (cbText > 0) {
-		SciCall_SetModEventMask(SC_MOD_NONE);
-		SciCall_AppendText(cbText, pchText);
 		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
+		SciCall_AppendText(cbText, pchText);
 	}
 	if (pchText != NULL) {
 		NP2HeapFree(pchText);
@@ -254,9 +252,8 @@ void EditConvertToLargeMode(void) {
 	FileVars_Apply(&fvCurFile);
 
 	if (length > 0) {
-		SciCall_SetModEventMask(SC_MOD_NONE);
-		SciCall_AppendText(length, pchText);
 		SciCall_SetModEventMask(SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT);
+		SciCall_AppendText(length, pchText);
 	}
 	if (pchText != NULL) {
 		NP2HeapFree(pchText);


### PR DESCRIPTION
Fix https://github.com/zufuliu/notepad2/issues/321. Trigger `UpdateLineNumberWidth` for encoding conversion (`EditConvertText`).

Set `modEventMask` before `NotifyModified`:

https://github.com/zufuliu/notepad2/blob/d15282f22616891d82a40534ac37253225fcc8b9/scintilla/src/Editor.cxx#L7952-L7954

https://github.com/zufuliu/notepad2/blob/d15282f22616891d82a40534ac37253225fcc8b9/scintilla/src/Editor.cxx#L2835-L2844

https://github.com/zufuliu/notepad2/blob/d15282f22616891d82a40534ac37253225fcc8b9/src/Notepad2.c#L5094-L5099
