### PR TITLE
Make CI adopt current commit hash as VERSION_HASH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
+
     - name: MSVC x64 Release
       run: |
         CALL "build\VS2017\build.bat" Build x64 Release 1
@@ -72,6 +76,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
 
     - name: Install LLVM
       run: |
@@ -133,6 +141,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
+
     - name: Install llvm-mingw
       run: |
         CALL "build\install_mingw.bat" llvm
@@ -193,6 +205,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
+
     - name: Install GCC and Clang
       run: |
         CALL "build\install_mingw.bat" ucrt
@@ -243,6 +259,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
+
     - name: Install GCC and Clang
       run: |
         CALL "build\install_mingw.bat" x86_64
@@ -292,6 +312,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Update Version Hash
+      run: |
+        "c:/Program Files/Git/usr/bin/sed" -i "s/^\(.\+\)[0-9a-f]\{8\}\(.\+\)$/\1%GITHUB_SHA:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
 
     - name: Install GCC and Clang
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,11 @@ matrix:
       compiler: Clang
 
 # No reversion when shallow clone is enabled.
-# before_build:
+before_build:
 #  - cmd: CALL update_rev.bat
+  - cmd: |
+      ECHO Update Version Hash
+      "c:/Program Files/Git/usr/bin/sed" -i "s/\(.\+\)[0-9a-f]\{8\}\(.\+\)/\1%APPVEYOR_REPO_COMMIT:~0,8%\2/gm" ./src/VersionRev.h ./metapath/src/VersionRev.h
 
 for:
   - # MSVC x64 Debug


### PR DESCRIPTION
Although without new revision number, updated version hash still helps to distinguish development versions one another. And it's cheap with shallow clone.