### PR TITLE
Styles: Set PKGBUILD and APKBUILD syntax highlighting as shell script

### DIFF
--- a/doc/FileExt.txt
+++ b/doc/FileExt.txt
@@ -493,6 +493,9 @@ Shell Script
 	.profile
 	mozconfig		Firefox Build Configuration
 
+	APKBUILD		Alpine Linux packaging script
+	PKGBUILD		Arch Linux packaging script
+
 Swift Source
 	swift
 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -2568,7 +2568,7 @@ static PEDITLEXER Style_GetLexerFromFile(LPCWSTR lpszFile, bool bCGIGuess, LPCWS
 		else if (StrCaseEqual(lpszName, L"Rakefile") || StrCaseEqual(lpszName, L"Podfile")) {
 			pLexNew = &lexRuby;
 		}
-		else if (StrCaseEqual(lpszName, L"mozconfig")) {
+		else if (StrCaseEqual(lpszName, L"mozconfig") || StrCaseEqual(lpszName, L"APKBUILD") || StrCaseEqual(lpszName, L"PKGBUILD")) {
 			pLexNew = &lexBash;
 		}
 		// Boost build


### PR DESCRIPTION
Both PKGBUILD and APKBUILD files are actually shell script. See
* https://wiki.archlinux.org/title/PKGBUILD
* https://wiki.alpinelinux.org/wiki/APKBUILD_Reference