### PR TITLE
Added dark mode color configuration for CSV lexer

### DIFF
--- a/doc/Notepad2 DarkTheme.ini
+++ b/doc/Notepad2 DarkTheme.ini
@@ -34,6 +34,18 @@ Operator=fore:#A349A4
 [CSS Style Sheet]
 Variable=italic; fore:#0080FF
 Operator=fore:#A349A4
+[CSV File]
+Column 1=fore:#F04200
+Column 2=fore:#FF860D
+Column 3=fore:#D2D200
+Column 4=fore:#02A800
+Column 5=fore:#0ACFCF
+Column 6=fore:#0095FF
+Column 7=fore:#A56EF3
+Column 8=fore:#B98200
+Column 9=fore:#8FAE00
+Column 10=fore:#84B4BD
+Delimiter=fore:#A0A0A0
 [Java Source]
 Keyword=fore:#00B050
 Type Keyword=fore:#00B050


### PR DESCRIPTION
As requested here is the colour configuration for dark mode, here is a small preview:

![image](https://user-images.githubusercontent.com/111676425/203809783-c0dde175-0e2b-421c-bd5b-cc45cef0af10.png)

