### PR TITLE
Improve `Run Command` with environment variables containing spaces

### DIFF
--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -445,8 +445,9 @@ static INT_PTR CALLBACK RunDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM l
 			WCHAR szFile[MAX_PATH * 2];
 
 			GetDlgItemText(hwnd, IDC_COMMANDLINE, szArgs, COUNTOF(szArgs));
-			ExpandEnvironmentStringsEx(szArgs, COUNTOF(szArgs));
 			ExtractFirstArgument(szArgs, szFile, szArg2);
+			ExpandEnvironmentStringsEx(szFile, COUNTOF(szFile));
+			ExpandEnvironmentStringsEx(szArg2, COUNTOF(szArg2));
 
 			WCHAR szFilter[256];
 			GetString(IDS_FILTER_EXE, szFilter, COUNTOF(szFilter));

--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -501,7 +501,6 @@ static INT_PTR CALLBACK RunDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM l
 				bool bQuickExit = false;
 				WCHAR arg2[MAX_PATH];
 
-				ExpandEnvironmentStringsEx(arg1, COUNTOF(arg1));
 				ExtractFirstArgument(arg1, arg1, arg2);
 
 				if (StrCaseEqual(arg1, L"notepad2") || StrCaseEqual(arg1, L"notepad2.exe")) {
@@ -518,7 +517,7 @@ static INT_PTR CALLBACK RunDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM l
 				SHELLEXECUTEINFO sei;
 				memset(&sei, 0, sizeof(SHELLEXECUTEINFO));
 				sei.cbSize = sizeof(SHELLEXECUTEINFO);
-				sei.fMask = 0;
+				sei.fMask = SEE_MASK_DOENVSUBST;
 				sei.hwnd = hwnd;
 				sei.lpVerb = NULL;
 				sei.lpFile = arg1;

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -6930,7 +6930,6 @@ void EditSelectionAction(int action) {
 	LPWSTR lpszCommand = (LPWSTR)NP2HeapAlloc(sizeof(WCHAR) * (cchEscapedW + COUNTOF(szCmdTemplate) + MAX_PATH + 32));
 	const size_t cbCommand = NP2HeapSize(lpszCommand);
 	wsprintf(lpszCommand, szCmdTemplate, pszEscapedW);
-	ExpandEnvironmentStringsEx(lpszCommand, (DWORD)(cbCommand / sizeof(WCHAR)));
 
 	LPWSTR lpszArgs = (LPWSTR)NP2HeapAlloc(cbCommand);
 	ExtractFirstArgument(lpszCommand, lpszCommand, lpszArgs);
@@ -6944,7 +6943,7 @@ void EditSelectionAction(int action) {
 	SHELLEXECUTEINFO sei;
 	memset(&sei, 0, sizeof(SHELLEXECUTEINFO));
 	sei.cbSize = sizeof(SHELLEXECUTEINFO);
-	sei.fMask = SEE_MASK_NOZONECHECKS;
+	sei.fMask = SEE_MASK_DOENVSUBST | SEE_MASK_NOZONECHECKS;
 	sei.hwnd = NULL;
 	sei.lpVerb = NULL;
 	sei.lpFile = lpszCommand;


### PR DESCRIPTION
Align with `Win + R`, for convenience.
Test example: `%ProgramFiles%`.